### PR TITLE
Update and modernize gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.gradle
+build/
+gradle-app.setting
+!gradle-wrapper.jar
+.gradletasknamecache
+**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,13 @@ allprojects {
     version = '1.0.0'
 }
 
-sourceCompatibility = 11
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
 
 repositories {
-    // Use jcenter for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
     jcenter()
     mavenCentral()
 }
@@ -25,13 +27,13 @@ dependencies {
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
 
     // Use JUnit test framework
-    testCompile "org.junit.jupiter:junit-jupiter-params:5.5.2"
-    testRuntime "org.junit.jupiter:junit-jupiter-engine:5.5.2"
-    testRuntime "org.junit.platform:junit-platform-runner:1.5.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.2"
+    testRuntimeOnly "org.junit.platform:junit-platform-runner:1.5.2"
 
     // https://mvnrepository.com/artifact/org.antlr/antlr4-runtime
     antlr 'org.antlr:antlr4:4.7.1'
-    compile "org.antlr:antlr4-intellij-adaptor:0.1"
+    implementation "org.antlr:antlr4-intellij-adaptor:0.1"
 }
 
 // Make tests run via the CLI make some noise

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,12 @@ plugins {
     // Apply the java-library plugin to add support for Java Library
     id 'java-library'
     id 'antlr'
-    id "com.diffplug.spotless" version "5.8.2"
+    id "com.diffplug.spotless" version "5.12.4"
 }
 
-allprojects {
-    group = 'io.txcl.mingds'
-    version = '1.0.0'
-}
+
+group = 'io.txcl.mingds'
+version = '1.0.0'
 
 java {
     toolchain {
@@ -43,6 +42,18 @@ test {
     afterTest { desc, result ->
         logger.quiet "Executing test [${desc.className}]->${desc.name} with result: ${result.resultType}"
     }
+}
+
+//NOTE(G3): Gradle v7.0 was throwing some noisy implicit task dependency warnings
+// that were disabling execution optimizations.. This explicitly sets those dependenices
+project.afterEvaluate {
+    spotlessJava.dependsOn(
+            'compileJava',
+            'compileTestJava',
+            'processResources',
+            'processTestResources',
+            'test'
+    )
 }
 
 spotless {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Tue Apr 20 15:41:50 PDT 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
# TL;DR
Lets bump gradle to _modern_. This way we can set the java toolchain for hosts that don't have java 11 like mine.

While in there, clean up the build file and ignore implicit dependency execution optimization disable warnings from spotless apply